### PR TITLE
Enable deploy multiple rollups

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,9 +26,6 @@
 [submodule "packages/contracts-bedrock/lib/lib-keccak"]
 	path = packages/contracts-bedrock/lib/lib-keccak
 	url = https://github.com/ethereum-optimism/lib-keccak
-[submodule "nodekit-l1"]
-	path = nodekit-l1
-	url = https://github.com/AnomalyFi/nodekit-l1
 [submodule "nodekit-zk"]
 	path = nodekit-zk
 	url = https://github.com/AnomalyFi/nodekit-zk

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -407,6 +407,9 @@ def devnet_l1_genesis(paths, deploy_config: str):
 def devnet_deploy(paths, args):
     nodekit = args.nodekit
     l2 = args.l2
+    l2_chain_id = int(args.l2_chain_id)
+    # which will be prepended to names of docker volumnes and services so we can run several rollups
+    composer_project_name = f'op-devnet_{l2_chain_id}'
     l2_provider_url = args.l2_provider_url
     compose_file = args.compose_file
     l1_rpc_url = args.l1_rpc_url
@@ -425,6 +428,7 @@ def devnet_deploy(paths, args):
 
     print(f'using config {conf}')
 
+    # TODO: to be removed since we don't need to launch l2 ourselves
     # if os.path.exists(paths.genesis_l1_path) and os.path.isfile(paths.genesis_l1_path):
     #     log.info('L1 genesis already generated.')
     # elif not args.deploy_l2:
@@ -498,6 +502,7 @@ def devnet_deploy(paths, args):
         'SEQ_ADDR': seq_addr,
         'SEQ_CHAIN_ID': seq_chain_id,
         'OP1_L2_RPC_PORT': str(l2_provider_port),
+        'COMPOSE_PROJECT_NAME': composer_project_name
     })
 
     # l2_provider_port = int(l2_provider_url.split(':')[-1])
@@ -525,7 +530,8 @@ def devnet_deploy(paths, args):
         'SEQ_ADDR': seq_addr,
         'SEQ_CHAIN_ID': seq_chain_id,
         'L1WS': l1_ws_url,
-        'L1RPC': l1_rpc_url
+        'L1RPC': l1_rpc_url,
+        'COMPOSE_PROJECT_NAME': composer_project_name
     })
 
     #log.info('Starting block explorer')

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -497,6 +497,8 @@ def devnet_deploy(paths, args):
     l2_provider_port = int(l2_provider_url.split(':')[-1])
     l2_provider_http = l2_provider_url
 
+    log.info(f'l2 provider http: {l2_provider_http}, port: {l2_provider_port}')
+
     log.info('Bringing up L2.')
     run_command(['docker', 'compose', '-f', compose_file, 'up', '-d', f'{l2}-l2', f'{l2}-geth-proxy'], cwd=paths.ops_bedrock_dir, env={
         'PWD': paths.ops_bedrock_dir,
@@ -616,6 +618,7 @@ def wait_for_rpc_server(url):
             conn.request('POST', '/', body, headers)
             response = conn.getresponse()
             conn.close()
+            log.info(response)
             if response.status < 300:
                 log.info(f'RPC server at {url} ready')
                 return

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -48,6 +48,7 @@ parser.add_argument('--l1-ws-url', help='l1 ws url', type=str, default='ws://loc
 parser.add_argument('--launch-l2', help='if launch l2', type=bool, action=argparse.BooleanOptionalAction)
 parser.add_argument('--launch-nodekit-l1', help='if launch nodekit l1', type=bool, action=argparse.BooleanOptionalAction)
 parser.add_argument('--nodekit-l1-dir', help='directory of nodekit-l1', type=str, default='nodekit-l1')
+parser.add_argument('--nodekit-contract', help='nodekit commitment contract address on l1', type=str, default='')
 parser.add_argument('--seq-url',  help='seq url', type=str, default='http://127.0.0.1:37029/ext/bc/56iQygPt5wrSCqZSLVwKyT7hAEdraXqDsYqWtWoAWaZSKDSDm')
 parser.add_argument('--l1-chain-id', help='chain id of l1', type=str, default='32382')
 parser.add_argument('--l2-chain-id', help='chain id of l2', type=str, default='45200')
@@ -281,6 +282,7 @@ def deploy_contracts(paths, args, deploy_config: str, deploy_l2: bool, jwt_secre
     account = res['result'][0]
     log.info(f'Deploying with {account}')
     mnemonic_words = args.mnemonic_words
+    sequencer_contract_addr: str = args.nodekit_contract
 
     # # wait transaction indexing service to be available
     # time.sleep(30)
@@ -339,7 +341,7 @@ def deploy_contracts(paths, args, deploy_config: str, deploy_l2: bool, jwt_secre
     # or will lead to unable to verify l2 blocks
     # sequencer_contract_addr = get_nodekit_zk_contract_addr(paths, args)
     devnetL1_conf = read_json(paths.devnet_config_path)
-    # devnetL1_conf['nodekitContractAddress'] = sequencer_contract_addr
+    devnetL1_conf['nodekitContractAddress'] = sequencer_contract_addr
     write_json(paths.devnet_config_path, devnetL1_conf)
 
     shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)


### PR DESCRIPTION
Enable opstack-deployment to deploy multiple optimisim rollups

- [x] Remove deployment of nodekit-l1 and nodekit-zk in this repository
- [x] Update contracts deployment config initialization function to accept l2 chain id from flag set
- [x] Enable deployment of serveral rollups on the deployment machine by specifying op chain docker working project name
- [x] Tests