### PR TITLE
derivation pipeline with chunks from DA

### DIFF
--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sidecar"
 )
 
 // The attributes queue sits in between the batch queue and the engine queue
@@ -33,15 +35,17 @@ type AttributesQueue struct {
 	builder      AttributesBuilder
 	prev         *BatchQueue
 	batch        *SingularBatch
+	sidecar      sidecar.RPCInterface
 	isLastInSpan bool
 }
 
-func NewAttributesQueue(log log.Logger, cfg *rollup.Config, builder AttributesBuilder, prev *BatchQueue) *AttributesQueue {
+func NewAttributesQueue(log log.Logger, cfg *rollup.Config, builder AttributesBuilder, prev *BatchQueue, sidecar sidecar.RPCInterface) *AttributesQueue {
 	return &AttributesQueue{
 		log:     log,
 		config:  cfg,
 		builder: builder,
 		prev:    prev,
+		sidecar: sidecar,
 	}
 }
 
@@ -70,7 +74,6 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 		aq.isLastInSpan = false
 		return &attr, nil
 	}
-
 }
 
 // createNextAttributes transforms a batch into a payload attributes. This sets `NoTxPool` and appends the batched transactions
@@ -94,7 +97,16 @@ func (aq *AttributesQueue) createNextAttributes(ctx context.Context, batch *Sing
 	// we are verifying, not sequencing, we've got all transactions and do not pull from the tx-pool
 	// (that would make the block derivation non-deterministic)
 	attrs.NoTxPool = true
-	attrs.Transactions = append(attrs.Transactions, batch.Transactions...)
+	// try fetch from sidecar and if the payload is managed by NodeKit, we will fetch txs from sidecar and start verifying
+	nodekitPayloadTxs, err := aq.sidecar.GetPayloadFromDA(l2SafeHead.Number + 1)
+	if err != nil && errors.Is(err, sidecar.ErrPayloadNotManagedByNodekit) {
+		attrs.Transactions = append(attrs.Transactions, batch.Transactions...)
+	} else if err == nil {
+		attrs.Transactions = append(attrs.Transactions, nodekitPayloadTxs...)
+	} else {
+		// should only happen when sidecar is down
+		return nil, err
+	}
 
 	aq.log.Info("generated attributes in payload queue", "txs", len(attrs.Transactions), "timestamp", batch.Timestamp)
 

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -81,7 +81,7 @@ func TestAttributesQueue(t *testing.T) {
 	}
 	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l2Fetcher)
 
-	aq := NewAttributesQueue(testlog.Logger(t, log.LevelError), cfg, attrBuilder, nil)
+	aq := NewAttributesQueue(testlog.Logger(t, log.LevelError), cfg, attrBuilder, nil, nil)
 
 	actual, err := aq.createNextAttributes(context.Background(), &batch, safeHead)
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/nodekit"
+	"github.com/ethereum-optimism/optimism/op-service/sidecar"
 )
 
 type Metrics interface {
@@ -72,7 +73,7 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.
 
-func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher, plasma PlasmaInputFetcher, l2Source L2Source, attrsSequencer *AttributesSequencer, engine LocalEngineControl, metrics Metrics, syncCfg *sync.Config, safeHeadListener SafeHeadListener) *DerivationPipeline {
+func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher, plasma PlasmaInputFetcher, l2Source L2Source, attrsSequencer *AttributesSequencer, engine LocalEngineControl, metrics Metrics, syncCfg *sync.Config, safeHeadListener SafeHeadListener, sidecar sidecar.RPCInterface) *DerivationPipeline {
 
 	var nodekitProvider NodeKitL1Provider
 	if rollupCfg.NodeKitContractAddress != nil {
@@ -87,7 +88,7 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 	chInReader := NewChannelInReader(rollupCfg, log, bank, metrics)
 	batchQueue := NewBatchQueue(log, rollupCfg, chInReader, nodekitProvider, l2Source)
 	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1Fetcher, l2Source)
-	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchQueue)
+	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchQueue, sidecar)
 
 	// Step stages
 	eng := NewEngineQueue(log, rollupCfg, l2Source, engine, metrics, attributesQueue, l1Fetcher, attrsSequencer, syncCfg, safeHeadListener)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -144,7 +144,7 @@ func NewDriver(
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	attrsSequencer := derive.NewAttributesSequencer(log, findL1Origin, attrBuilder, broadcastPayloadAttrs, metrics)
 	// derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, attrsSequencer, engine, metrics, syncCfg, safeHeadListener)
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, attrsSequencer, engine, metrics, syncCfg, safeHeadListener)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, attrsSequencer, engine, metrics, syncCfg, safeHeadListener, sidecarClient)
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log) // Only use the metered engine in the sequencer b/c it records sequencing metrics.
 	sequencer := NewSequencer(log, cfg, meteredEngine, l2, attrBuilder, findL1Origin, sidecarClient, metrics, broadcastPayloadAttrs)
 	driverCtx, driverCancel := context.WithCancel(context.Background())

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -362,12 +362,13 @@ func (d *Sequencer) PlanNextSequencerAction() time.Duration {
 		return time.Second * time.Duration(d.rollupCfg.BlockTime)
 	}
 
-	rollupStatus, err := d.sidecar.RollupStatus()
+	head := d.engine.UnsafeL2Head()
+	rollupStatus, err := d.sidecar.RollupStatus(head.Number + 1)
 	if err != nil {
 		d.log.Warn("err querying rollup status", "err", err)
 	}
 	switch rollupStatus {
-	case sidecar.ROLLUP_REGISTERED:
+	case sidecar.RollupManagedByNodeKit:
 		return d.planNextNodeKitSequencerAction()
 	default:
 		return d.planNextLegacySequencerAction()
@@ -508,14 +509,15 @@ func (d *Sequencer) CancelBuildingBlock(ctx context.Context) {
 // but the derivation can continue to reset until the chain is correct.
 // If the engine is currently building safe blocks, then that building is not interrupted, and sequencing is delayed.
 func (d *Sequencer) RunNextSequencerAction(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (*eth.ExecutionPayloadEnvelope, error) {
-	rollupStatus, err := d.sidecar.RollupStatus()
+	head := d.engine.UnsafeL2Head()
+	rollupStatus, err := d.sidecar.RollupStatus(head.Number + 1)
 	if err != nil {
 		d.log.Warn("error querying rollup status")
 	}
 
 	onto, buildingID, safe := d.engine.BuildingPayload()
 	// if still building under legacy mode but rollup is registered on Arcadia, we cancel that
-	if buildingID != (eth.PayloadID{}) && rollupStatus == sidecar.ROLLUP_REGISTERED {
+	if buildingID != (eth.PayloadID{}) && rollupStatus == sidecar.RollupManagedByNodeKit {
 		d.log.Debug("canceling payload", "payloadID", buildingID)
 		err := d.engine.CancelPayload(ctx, true)
 		if err != nil {
@@ -539,9 +541,19 @@ func (d *Sequencer) RunNextSequencerAction(ctx context.Context, agossip async.As
 	}
 
 	switch rollupStatus {
-	case sidecar.ROLLUP_REGISTERED:
+	case sidecar.RollupManagedByNodeKit:
 		d.log.Debug("rollup registered, building arcadia block")
-		return d.buildArcadiaBatch(ctx, agossip, sequencerConductor)
+		payload, err := d.buildArcadiaBatch(ctx, agossip, sequencerConductor)
+		if err != sidecar.ErrArcadiaDown {
+			return payload, err
+		}
+		// upon arcadia down, we are safe to fallback to local production
+		// - if the payload on Arcadia is delivered by the chunk is not submitted to DA, derivation pipeline will detect that
+		// and reset the chain to the safe head
+		// - if the payload on Arcadia is undelivered but the chunk is submitted to DA, derivation pipeline will also detect that and reset
+		// upon starting again with building new payload, it will call sidecar for payload and sidecar should check if there's anything left on DA
+		// to be delivered
+		fallthrough
 	default:
 		d.log.Debug("rollup exited or not registered, building legacy block")
 		return d.buildLegacyBlock(ctx, agossip, sequencerConductor, buildingID != eth.PayloadID{} || agossip.Get() != nil)

--- a/op-service/sidecar/client.go
+++ b/op-service/sidecar/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,14 +17,19 @@ import (
 const HEADER_ROLLUP_SIG = "X-ROLLUP-SEQ-SIG"
 
 const (
-	ROLLUP_REGISTERED = iota
-	ROLLUP_EXITED
-	ROLLUP_NOT_REGISTERED
+	RollupStatusUnknown = iota
+	RollupManagedByNodeKit
+	RollupNotManagedByNodeKit
 )
 
 const (
 	pathGetPayload   = "/rollup/getpayload"
 	pathRollupStatus = "/rollup/status"
+)
+
+var (
+	ErrPayloadNotManagedByNodekit = errors.New("payload at given height is not produced by NodeKit")
+	ErrArcadiaDown                = errors.New("arcadia is down, need reorg")
 )
 
 type ClientConfig struct {
@@ -37,7 +43,8 @@ type ClientConfig struct {
 
 type RPCInterface interface {
 	GetPayload(height uint64) ([]hexutil.Bytes, error)
-	RollupStatus() (int, error)
+	GetPayloadFromDA(height uint64) ([]hexutil.Bytes, error)
+	RollupStatus(height uint64) (int, error)
 }
 
 var _ RPCInterface = (*Client)(nil)
@@ -45,6 +52,8 @@ var _ RPCInterface = (*Client)(nil)
 type Client struct {
 	cfg ClientConfig
 	log log.Logger
+
+	chainID string
 
 	sk         *bls.SecretKey
 	pk         *bls.PublicKey
@@ -106,6 +115,9 @@ func (c *Client) GetPayload(height uint64) ([]hexutil.Bytes, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode != http.StatusBadRequest {
+			return nil, ErrArcadiaDown
+		}
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			c.log.Warn("unable to read response body", "err", err)
@@ -127,34 +139,67 @@ func (c *Client) GetPayload(height uint64) ([]hexutil.Bytes, error) {
 	return payloadResp.Transactions, nil
 }
 
-func (c *Client) RollupStatus() (int, error) {
+// TODO: to be implemented
+func (c *Client) GetPayloadFromDA(height uint64) ([]hexutil.Bytes, error) {
+	return nil, nil
+}
+
+type RollupStatusRequest struct {
+	ChainID string `json:"chainID"`
+	Height  uint64 `json:"height"`
+}
+
+type RollupStatusResponse struct {
+	Status int `json:"status"`
+}
+
+func (c *Client) RollupStatus(height uint64) (int, error) {
 	endpoint := c.cfg.SidecarUrl + pathRollupStatus
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
-	if err != nil {
-		return ROLLUP_NOT_REGISTERED, err
+	statusReq := RollupStatusRequest{
+		ChainID: c.chainID,
+		Height:  height,
 	}
+
+	reqBytes, err := json.Marshal(statusReq)
+	if err != nil {
+		return RollupStatusUnknown, err
+	}
+	reqHash, err := sha256HashPayload(reqBytes)
+	if err != nil {
+		return RollupStatusUnknown, err
+	}
+	sig := bls.Sign(c.sk, reqHash)
+	sigBytes := sig.Bytes()
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return RollupStatusUnknown, err
+	}
+	req.Header.Set(HEADER_ROLLUP_SIG, hexutil.Encode(sigBytes[:]))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return ROLLUP_NOT_REGISTERED, err
+		return RollupStatusUnknown, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusTooEarly {
-		return ROLLUP_NOT_REGISTERED, nil
-	} else if resp.StatusCode != http.StatusOK {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			c.log.Warn("unable to read response body", "err", err)
-			return ROLLUP_NOT_REGISTERED, nil
-		}
-		c.log.Warn("rollup status error:", "err", string(respBody))
-		return ROLLUP_NOT_REGISTERED, nil
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return RollupStatusUnknown, nil
 	}
 
-	return ROLLUP_REGISTERED, nil
+	if resp.StatusCode != http.StatusOK {
+		c.log.Error("unable to query rollup status", "err", string(respBody))
+		// either signature not correct or sidecar is down
+		return RollupStatusUnknown, nil
+	}
+
+	statusResp := new(RollupStatusResponse)
+	if err := json.Unmarshal(respBody, statusResp); err != nil {
+		return RollupStatusUnknown, nil
+	}
+	return statusResp.Status, nil
 }
 
 func sha256HashPayload(payload []byte) ([]byte, error) {


### PR DESCRIPTION
This PR is a safety enforcement to rollups that uses nodekit stack to guarantee that even if Arcadia is down and can't no longer recover, the rollups still can reset/derive the chain to the highest settled chunk layer on Arcadia iff the chunks from before and this layer is settled on DA, which result the same view to all benign rollups, ultimately there will be no asset loss lead by the crash of Arcadia. 

Functionality include
- derivation pipeline call `GetPayloadFromDA` to check if certain height of the block is managed by NodeKit in the derivation pipelinne, if so, it will force the transactions in the safe attributes to be from sidecar instead of the batch from the legacy block production and batcher, this covers the case
    - Arcadia is down but chunks comprise the delivered payload is not submitted to DA in block production, which will be detected by the derivation pipeline and trigger the reset. 
- block production by checking rollup status by the `ChainID` and `Height`, where covers
    - Arcadia is on and rollup is not registered
    - Arcadia is on and rollup is registered
    - Arcadia is down but chunks comprise the rollup block is submitted to DA and payload for the height is not fetched, which we should build the payload from DA otherwise fallback to local production